### PR TITLE
Section23 prep-script for VM image

### DIFF
--- a/section23/fsl_glm_in_image.sh
+++ b/section23/fsl_glm_in_image.sh
@@ -16,11 +16,11 @@ echo "Workdir at `pwd`"
 # -- part 1: DICOM conversion ---
 
 # we are creating a BIDS compatible variant of our MR dataset
-datalad create bids
+datalad create localizer_scans
 # running everything from the root of a dataset enables the consistent
 # use of relative paths in all analysis code and makes an analysis
 # implementation more portable
-cd bids
+cd localizer_scans
 
 # install input data as a subdataset, to enable identity tracking
 # an automated content retrieval, if necessary
@@ -65,7 +65,7 @@ datalad create glm_analysis
 cd glm_analysis
 
 # get the BIDS raw dataset (no actual content)
-datalad install -d . -s ../bids inputs/rawdata
+datalad install -d . -s ../localizer_scans inputs/rawdata
 
 # apply useful dataset preconfiguration
 datalad run-procedure setup_yoda_dataset

--- a/section23/fsl_glm_in_image.sh
+++ b/section23/fsl_glm_in_image.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+set -e -u
+
+# remember the original directory, just to make some admin parts easier
+# but generally irrelevant
+srcdir=$(pwd)
+wdir=${1:-demo}
+mkdir -p ${wdir}
+cd ${wdir}
+echo "Workdir at `pwd`"
+
+# =========================
+# XXX actual demo from here
+
+# -- part 1: DICOM conversion ---
+
+# we are creating a BIDS compatible variant of our MR dataset
+datalad create bids
+# running everything from the root of a dataset enables the consistent
+# use of relative paths in all analysis code and makes an analysis
+# implementation more portable
+cd bids
+
+# install input data as a subdataset, to enable identity tracking
+# an automated content retrieval, if necessary
+datalad install -d . -s https://github.com/datalad/example-dicom-functional.git inputs/rawdata
+
+# get a ready-made container with the dicom converter
+datalad containers-add heudiconv -u ~/images/heudiconv.simg \
+  --call-fmt 'singularity exec -B /tmp --bind {{pwd}} -H {{pwd}} {img} {cmd}'
+
+# with `datalad (containers-)run` we can capture basic provenance information on any
+# analysis step: what files where produced by which command, based on
+# what kind and state of input data
+# perform the DICOM conversion
+# containers-run will automatically execute this in the registered
+# container (no need to think about it)
+# --input ensures that datalad will obtain any matching files (if needed)
+# --ouput ensure that datalad unlocks any matching files so that
+#   the payload command can alter them.
+datalad containers-run -m "Convert sub-02 DICOMs into BIDS" \
+   --input inputs/rawdata/dicoms \
+   --output . \
+   heudiconv -f reproin -s 02 -c dcm2niix -b -l '' --minmeta -a . \
+       -o /tmp/heudiconv.sub-02 --files inputs/rawdata/dicoms
+
+# Simplify: https://github.com/datalad/datalad/issues/2512
+datalad run -m "Import stimulation events" \
+   --input inputs/rawdata/events.tsv \
+   --output sub-02/func/sub-02_task-oneback_run-01_events.tsv \
+   cp {inputs} {outputs}
+
+# at this point we have a complete BIDS raw dataset in a clean Git repository
+# that is reproducible from the raw DICOM file state
+
+cd ..
+
+# -- part 2: (GLM) analysis ---
+
+# any analysis is its own project, as any raw data can be analyzed in many different
+# ways
+
+datalad create glm_analysis
+cd glm_analysis
+
+# get the BIDS raw dataset (no actual content)
+datalad install -d . -s ../bids inputs/rawdata
+
+# apply useful dataset preconfiguration
+datalad run-procedure setup_yoda_dataset
+
+# inject external code, such that its location is tracked
+datalad download-url -O code/events2ev3.sh https://raw.githubusercontent.com/ReproNim/ohbm2018-training/master/section23/scripts/events2ev3.sh
+datalad download-url -O code/ffa_design.fsf https://raw.githubusercontent.com/ReproNim/ohbm2018-training/master/section23/scripts/ffa_design.fsf
+
+
+# here we convert BIDS events.tsv into a format accessible to FSL
+# TODO simplify: https://github.com/datalad/datalad/issues/2512
+datalad run -m 'Build FSL EV3 design files' \
+    --input inputs/rawdata/sub-02/func/sub-02_task-oneback_run-01_events.tsv \
+    --output 'sub-02/onsets' \
+    bash code/events2ev3.sh sub-02 {inputs}
+
+datalad run \
+     -m "FSL FEAT analysis config script" \
+     --output sub-02/1stlvl_design.fsf \
+     bash -c 'sed -e "s,##BASEPATH##,{pwd},g" -e "s,##SUB##,sub-02,g" \
+         code/ffa_design.fsf > {outputs}'
+
+
+# use a pre-crafted container image for FSL
+# the local one is broken, though
+#datalad containers-add fsl -u ~/images/fsl.simg \
+datalad containers-add fsl -u shub://ReproNim/ohbm2018-training:fsln \
+  --call-fmt 'singularity exec -B /tmp --bind {{pwd}} -H {{pwd}} {img} {cmd}'
+
+# execute GLM analysis, this will capture the entire FSL output with
+# datalad
+datalad containers-run -m "sub-02 1st-level GLM" \
+    --input sub-02/1stlvl_design.fsf \
+    --input sub-02/onsets \
+    --input inputs/rawdata/sub-02/func/sub-02_task-oneback_run-01_bold.nii.gz \
+    --output sub-02/1stlvl_glm.feat \
+    feat {inputs[0]}
+
+# done
+
+# -- part 3: get ready for the afterlife
+
+# we can now instruct datalad to extract some essential metadata properties
+# of the dataset content, more than one extractor can be enabled, here is just
+# a demo config call that could be repeated/amended
+datalad run-procedure cfg_metadatatypes nifti1
+
+# with this configuration in place, metadata extraction can be performed
+# automatically
+datalad aggregate-metadata
+
+# and subsequently we can search for particular dataset content
+# e.g. all nifti files that FSL marked as coming from itself
+#datalad search --mode autofield nifti1.description:fsl5.0
+
+# at this point we have a complete record of this analysis
+# we can even ask datalad to export a script of all the steps
+# every recorded
+#datalad rerun --since= --script myanalysis.sh
+
+#cat myanalysis.sh


### PR DESCRIPTION
I made a new variant of the prep-script. Using VM path for images (avoids some downloads) and disables all the stuff meant for interactive demos. What follows is the code I ran inside the VM after importing the pristine OVA (`e789b13556ca0f517743e6a1da4f3fe0  /tmp/reprotraining.ova`):

All executed in $HOME inside the image

```bash
git config --global user.email johndoe@example.com
git config --global user.name "John Doe"
source activate section2

# neuroimaging extension install was missing dependencies
pip install --upgrade datalad-neuroimaging

# not really needed, but nice: install datalad stable release
pip install --upgrade datalad

# for the next one I actually did
#datalad install https://github.com/myyoda/ohbm2018-training
# to get this PR, but really it would be, after the PR is merged
datalad install https://github.com/ReproNim/ohbm2018-training

# it is super useful to have gitk and/or tig to inspect Git history
sudo apt-get install gitk tig

# replace broken FSL image in the VM with current one
singularity pull -n fsl.simg shub://ReproNim/ohbm2018-training:fsln
mv fsl.simg images/

# and run the beast
bash -x ohbm2018-training/section23/fsl_glm_in_image.sh

```

Notice that I could not use the FSL singularity image in the VM, but had to use shub://ReproNim/ohbm2018-training:fsln (the local one has no proper PATH environment setup).

Here is the full log of running the script:

```bash
(section2) vagrant@nitrcce:~$ bash -x ohbm2018-training/section23/fsl_glm_in_image.sh 
+ set -e -u
++ pwd
+ srcdir=/home/vagrant
+ wdir=demo
+ mkdir -p demo
+ cd demo
++ pwd
+ echo 'Workdir at /home/vagrant/demo'
Workdir at /home/vagrant/demo
+ datalad create bids
[INFO   ] Creating a new annex repo at /home/vagrant/demo/bids 
create(ok): /home/vagrant/demo/bids (dataset)                                                    
+ cd bids
+ datalad install -d . -s https://github.com/datalad/example-dicom-functional.git inputs/rawdata
[INFO   ] Cloning https://github.com/datalad/example-dicom-functional.git to '/home/vagrant/demo/bids/inputs/rawdata' 
install(ok): inputs/rawdata (dataset)                                                            
action summary:
  add (notneeded: 2, ok: 1)
  install (ok: 1)
  save (ok: 1)
+ datalad containers-add heudiconv -u /home/vagrant/images/heudiconv.simg --call-fmt 'singularity exec -B /tmp --bind {{pwd}} -H {{pwd}} {img} {cmd}'
save(ok): /home/vagrant/demo/bids (dataset)                                                      
containers_add(ok): /home/vagrant/demo/bids/.datalad/environments/heudiconv/image (file)
action summary:
  containers_add (ok: 1)
  save (ok: 1)
+ datalad containers-run -m 'Convert sub-02 DICOMs into BIDS' --input inputs/rawdata/dicoms --output . heudiconv -f reproin -s 02 -c dcm2niix -b -l '' --minmeta -a . -o /tmp/heudiconv.sub-02 --files inputs/rawdata/dicoms
[INFO   ] == Command start (output follows) ===== 
WARNING: Not mounting requested bind point (already mounted in container): /home/vagrant/demo/bids
INFO: Running heudiconv version 0.5.dev1
INFO: Analyzing 5460 dicoms
INFO: Filtering out 0 dicoms based on their filename
WARNING: dcmstack without support of pydicom >= 1.0 is detected. Adding a plug
INFO: Generated sequence info for 1 studies with 1 entries total
INFO: Processing sequence infos to deduce study/session
INFO: Study session for {'locator': 'Hanke/Stadler/0083_transrep2', 'subject': '02', 'session': None}
INFO: Need to process 1 study sessions
INFO: PROCESSING STARTS: {'subject': '02', 'outdir': '/tmp/heudiconv.sub-02/', 'session': None}
INFO: Processing 1 pre-sorted seqinfo entries
INFO: Reloading existing filegroup.json because /tmp/heudiconv.sub-02/.heudiconv/02/02.edit.txt exists
INFO: Doing conversion using dcm2niix
INFO: Converting ./sub-02/func/sub-02_task-oneback_run-01_bold (5460 DICOMs) -> ./sub-02/func . Converter: dcm2niix . Output types: ('nii.gz', 'dicom')
INFO: Generating grammar tables from /usr/lib/python3.5/lib2to3/Grammar.txt
INFO: Generating grammar tables from /usr/lib/python3.5/lib2to3/PatternGrammar.txt
INFO: [Node] Setting-up "convert" in "/tmp/dcm2niixmrs31zqi/convert".
INFO: [Node] Running "convert" ("nipype.interfaces.dcm2nii.Dcm2niix"), a CommandLine Interface with command:
dcm2niix -b y -z y -x n -t n -m n -f func -o . -s n -v n /tmp/dcm2niixmrs31zqi/convert
INFO: stdout 2018-06-12T18:28:23.930486:Chris Rorden's dcm2niiX version v1.0.20171215 (OpenJPEG build) GCC6.3.0 (64-bit Linux)
INFO: stdout 2018-06-12T18:28:23.930486:Found 5460 DICOM image(s)
INFO: stdout 2018-06-12T18:28:23.930486:swizzling 3rd and 4th dimensions (XYTZ -> XYZT), assuming interslice distance is 3.300000
INFO: stdout 2018-06-12T18:28:23.930486:Convert 5460 DICOM as ./func (80x80x35x156)
INFO: stdout 2018-06-12T18:28:23.930486:Philips Precise RS:RI:SS = 4.00757:0:0.0132383 (see PMC3998685)
INFO: stdout 2018-06-12T18:28:23.930486: R = raw value, P = precise value, D = displayed value
INFO: stdout 2018-06-12T18:28:23.930486: RS = rescale slope, RI = rescale intercept,  SS = scale slope
INFO: stdout 2018-06-12T18:28:23.930486: D = R * RS + RI    , P = D/(RS * SS)
INFO: stdout 2018-06-12T18:28:23.930486: D scl_slope:scl_inter = 4.00757:0
INFO: stdout 2018-06-12T18:28:23.930486: P scl_slope:scl_inter = 75.5384:0
INFO: stdout 2018-06-12T18:28:23.930486: Using P values ('-p n ' for D values)
INFO: stdout 2018-06-12T18:28:25.933874:compress: "/usr/bin/pigz" -n -f -6 "./func.nii"
INFO: stdout 2018-06-12T18:28:25.933874:Conversion required 3.857223 seconds (0.920270 for core code).
INFO: [Node] Finished "convert".
INFO: Populating template files under ./
INFO: PROCESSING DONE: {'subject': '02', 'outdir': '/tmp/heudiconv.sub-02/', 'session': None}
[INFO   ] == Command exit (modification check follows) ===== 
get(notneeded): .datalad/environments/heudiconv/image (file) [already present]                   
get(notneeded): inputs/rawdata/dicoms [no dataset annex, content already present]
unlock(ok): .datalad/environments/heudiconv/image (file)
add(ok): CHANGES (file)
add(ok): README (file)
add(ok): dataset_description.json (file)
add(ok): participants.tsv (file)
add(ok): sourcedata/README (file)
add(ok): sourcedata/sub-02/func/sub-02_task-oneback_run-01_bold.dicom.tgz (file)
add(ok): sub-02/func/sub-02_task-oneback_run-01_bold.json (file)
add(ok): sub-02/func/sub-02_task-oneback_run-01_bold.nii.gz (file)
add(ok): sub-02/func/sub-02_task-oneback_run-01_events.tsv (file)
add(ok): sub-02/sub-02_scans.tsv (file)
add(ok): task-oneback_bold.json (file)
add(ok): .datalad/environments/heudiconv/image (file)
save(ok): /home/vagrant/demo/bids (dataset)
action summary:
  add (ok: 12)
  get (notneeded: 2)
  save (ok: 1)
  unlock (ok: 1)
+ datalad run -m 'Import stimulation events' --input inputs/rawdata/events.tsv --output sub-02/func/sub-02_task-oneback_run-01_events.tsv cp '{inputs}' '{outputs}'
get(notneeded): inputs/rawdata/events.tsv [no dataset annex, content already present]
unlock(ok): sub-02/func/sub-02_task-oneback_run-01_events.tsv (file)
[INFO   ] == Command start (output follows) ===== 
[INFO   ] == Command exit (modification check follows) ===== 
add(ok): sub-02/func/sub-02_task-oneback_run-01_events.tsv (file)                                
save(ok): /home/vagrant/demo/bids (dataset)
action summary:
  add (ok: 1)
  get (notneeded: 1)
  save (ok: 1)
  unlock (ok: 1)
+ cd ..
+ datalad create glm_analysis
[INFO   ] Creating a new annex repo at /home/vagrant/demo/glm_analysis 
create(ok): /home/vagrant/demo/glm_analysis (dataset)                                            
+ cd glm_analysis
+ datalad install -d . -s ../bids inputs/rawdata
[INFO   ] Cloning ../bids to '/home/vagrant/demo/glm_analysis/inputs/rawdata' 
install(ok): inputs/rawdata (dataset)                                                            
action summary:
  add (notneeded: 2, ok: 1)
  install (ok: 1)
  save (ok: 1)
+ datalad run-procedure setup_yoda_dataset
[INFO   ] == Command start (output follows) ===== 
[INFO   ] == Command exit (modification check follows) =====                                     
add(notneeded): /home/vagrant/demo/glm_analysis (dataset)
+ datalad download-url -O code/events2ev3.sh https://raw.githubusercontent.com/ReproNim/ohbm2018-training/master/section23/scripts/events2ev3.sh
[INFO   ] Downloading 'https://raw.githubusercontent.com/ReproNim/ohbm2018-training/master/section23/scripts/events2ev3.sh' into 'code/events2ev3.sh' 
https://raw.githubusercontent.com/ReproNim/ohbm2018-training/master/section23/scripts/events2ev3.                                                                                                 download_url(ok): code/events2ev3.sh (file)
add(ok): code/events2ev3.sh (file) [non-large file; adding content to git repository]            
save(ok): /home/vagrant/demo/glm_analysis (dataset)
action summary:
  add (ok: 1)
  download_url (ok: 1)
  save (ok: 1)
+ datalad download-url -O code/ffa_design.fsf https://raw.githubusercontent.com/ReproNim/ohbm2018-training/master/section23/scripts/ffa_design.fsf
[INFO   ] Downloading 'https://raw.githubusercontent.com/ReproNim/ohbm2018-training/master/section23/scripts/ffa_design.fsf' into 'code/ffa_design.fsf' 
https://raw.githubusercontent.com/ReproNim/ohbm2018-training/master/section23/scripts/ffa_design.                                                                                                 download_url(ok): code/ffa_design.fsf (file)
add(ok): code/ffa_design.fsf (file) [non-large file; adding content to git repository]           
save(ok): /home/vagrant/demo/glm_analysis (dataset)
action summary:
  add (ok: 1)
  download_url (ok: 1)
  save (ok: 1)
+ datalad run -m 'Build FSL EV3 design files' --input inputs/rawdata/sub-02/func/sub-02_task-oneback_run-01_events.tsv --output sub-02/onsets bash code/events2ev3.sh sub-02 '{inputs}'
get(ok): inputs/rawdata/sub-02/func/sub-02_task-oneback_run-01_events.tsv (file) [from origin...]
[INFO   ] == Command start (output follows) ===== 
sub-02
1
[INFO   ] == Command exit (modification check follows) ===== 
add(ok): sub-02/onsets/run-1/body.txt (file)                                                     
add(ok): sub-02/onsets/run-1/face.txt (file)
add(ok): sub-02/onsets/run-1/house.txt (file)
add(ok): sub-02/onsets/run-1/object.txt (file)
add(ok): sub-02/onsets/run-1/scene.txt (file)
add(ok): sub-02/onsets/run-1/scramble.txt (file)
save(ok): /home/vagrant/demo/glm_analysis (dataset)
action summary:
  add (ok: 6)
  get (ok: 1)
  save (ok: 1)
+ datalad run -m 'FSL FEAT analysis config script' --output sub-02/1stlvl_design.fsf bash -c 'sed -e "s,##BASEPATH##,{pwd},g" -e "s,##SUB##,sub-02,g" \
         code/ffa_design.fsf > {outputs}'
unlock(ok): sub-02/onsets/run-1/body.txt (file)
unlock(ok): sub-02/onsets/run-1/face.txt (file)
unlock(ok): sub-02/onsets/run-1/house.txt (file)
unlock(ok): sub-02/onsets/run-1/object.txt (file)
unlock(ok): sub-02/onsets/run-1/scene.txt (file)
unlock(ok): sub-02/onsets/run-1/scramble.txt (file)
[INFO   ] == Command start (output follows) ===== 
[INFO   ] == Command exit (modification check follows) ===== 
add(ok): sub-02/1stlvl_design.fsf (file)                                                         
add(ok): sub-02/onsets/run-1/body.txt (file)
add(ok): sub-02/onsets/run-1/face.txt (file)
add(ok): sub-02/onsets/run-1/house.txt (file)
add(ok): sub-02/onsets/run-1/object.txt (file)
add(ok): sub-02/onsets/run-1/scene.txt (file)
add(ok): sub-02/onsets/run-1/scramble.txt (file)
save(ok): /home/vagrant/demo/glm_analysis (dataset)
action summary:
  add (ok: 7)
  save (ok: 1)
  unlock (ok: 6)
+ datalad containers-add fsl -u shub://ReproNim/ohbm2018-training:fsln --call-fmt 'singularity exec -B /tmp --bind {{pwd}} -H {{pwd}} {img} {cmd}'
save(ok): /home/vagrant/demo/glm_analysis (dataset)                                              
containers_add(ok): /home/vagrant/demo/glm_analysis/.datalad/environments/fsl/image (file)
action summary:
  containers_add (ok: 1)
  save (ok: 1)
+ datalad containers-run -m 'sub-02 1st-level GLM' --input sub-02/1stlvl_design.fsf --input sub-02/onsets --input inputs/rawdata/sub-02/func/sub-02_task-oneback_run-01_bold.nii.gz --output sub-02/1stlvl_glm.feat feat '{inputs[0]}'
[INFO   ] == Command start (output follows) =====                                                
WARNING: Not mounting requested bind point (already mounted in container): /home/vagrant/demo/glm_analysis
To view the FEAT progress and final report, point your web browser at /home/vagrant/demo/glm_analysis/sub-02/1stlvl_glm.feat/report_log.html
[INFO   ] == Command exit (modification check follows) ===== 
get(notneeded): sub-02/1stlvl_design.fsf (file) [already present]                                
get(notneeded): sub-02/onsets (directory) [nothing to get from /home/vagrant/demo/glm_analysis/sub-02/onsets]
get(notneeded): .datalad/environments/fsl/image (file) [already present]
get(ok): inputs/rawdata/sub-02/func/sub-02_task-oneback_run-01_bold.nii.gz (file) [from origin...]
unlock(ok): .datalad/environments/fsl/image (file)
unlock(ok): sub-02/1stlvl_design.fsf (file)
unlock(ok): sub-02/onsets/run-1/body.txt (file)
unlock(ok): sub-02/onsets/run-1/face.txt (file)
unlock(ok): sub-02/onsets/run-1/house.txt (file)
unlock(ok): sub-02/onsets/run-1/object.txt (file)
unlock(ok): sub-02/onsets/run-1/scene.txt (file)
unlock(ok): sub-02/onsets/run-1/scramble.txt (file)
add(ok): sub-02/1stlvl_glm.feat/absbrainthresh.txt (file)
add(ok): sub-02/1stlvl_glm.feat/cluster_mask_zstat1.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/cluster_zstat1.html (file)
add(ok): sub-02/1stlvl_glm.feat/cluster_zstat1.txt (file)
add(ok): sub-02/1stlvl_glm.feat/confoundevs.txt (file)
add(ok): sub-02/1stlvl_glm.feat/custom_timing_files/ev1.txt (file)
add(ok): sub-02/1stlvl_glm.feat/custom_timing_files/ev2.txt (file)
add(ok): sub-02/1stlvl_glm.feat/custom_timing_files/ev3.txt (file)
add(ok): sub-02/1stlvl_glm.feat/custom_timing_files/ev4.txt (file)
add(ok): sub-02/1stlvl_glm.feat/custom_timing_files/ev5.txt (file)
add(ok): sub-02/1stlvl_glm.feat/custom_timing_files/ev6.txt (file)
add(ok): sub-02/1stlvl_glm.feat/design.con (file)
add(ok): sub-02/1stlvl_glm.feat/design.frf (file)
add(ok): sub-02/1stlvl_glm.feat/design.fsf (file)
add(ok): sub-02/1stlvl_glm.feat/design.mat (file)
add(ok): sub-02/1stlvl_glm.feat/design.min (file)
add(ok): sub-02/1stlvl_glm.feat/design.png (file)
add(ok): sub-02/1stlvl_glm.feat/design.ppm (file)
add(ok): sub-02/1stlvl_glm.feat/design.trg (file)
add(ok): sub-02/1stlvl_glm.feat/design_cov.png (file)
add(ok): sub-02/1stlvl_glm.feat/design_cov.ppm (file)
add(ok): sub-02/1stlvl_glm.feat/example_func.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/filtered_func_data.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/lmax_zstat1.txt (file)
add(ok): sub-02/1stlvl_glm.feat/logs/feat0 (file)
add(ok): sub-02/1stlvl_glm.feat/logs/feat0_init.e11990 (file)
add(ok): sub-02/1stlvl_glm.feat/logs/feat0_init.o11990 (file)
add(ok): sub-02/1stlvl_glm.feat/logs/feat1 (file)
add(ok): sub-02/1stlvl_glm.feat/logs/feat1a_init (file)
add(ok): sub-02/1stlvl_glm.feat/logs/feat2_pre (file)
add(ok): sub-02/1stlvl_glm.feat/logs/feat2_pre.e12072 (file)
add(ok): sub-02/1stlvl_glm.feat/logs/feat2_pre.o12072 (file)
add(ok): sub-02/1stlvl_glm.feat/logs/feat3_film.e12519 (file)
add(ok): sub-02/1stlvl_glm.feat/logs/feat3_film.o12519 (file)
add(ok): sub-02/1stlvl_glm.feat/logs/feat3_stats (file)
add(ok): sub-02/1stlvl_glm.feat/logs/feat4_post (file)
add(ok): sub-02/1stlvl_glm.feat/logs/feat4_post.e12876 (file)
add(ok): sub-02/1stlvl_glm.feat/logs/feat4_post.o12876 (file)
add(ok): sub-02/1stlvl_glm.feat/logs/feat5_stop.e13513 (file)
add(ok): sub-02/1stlvl_glm.feat/logs/feat5_stop.o13513 (file)
add(ok): sub-02/1stlvl_glm.feat/logs/feat9 (file)
add(ok): sub-02/1stlvl_glm.feat/mask.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/mc/disp.png (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0000 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0001 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0002 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0003 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0004 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0005 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0006 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0007 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0008 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0009 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0010 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0011 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0012 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0013 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0014 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0015 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0016 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0017 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0018 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0019 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0020 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0021 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0022 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0023 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0024 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0025 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0026 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0027 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0028 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0029 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0030 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0031 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0032 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0033 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0034 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0035 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0036 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0037 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0038 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0039 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0040 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0041 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0042 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0043 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0044 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0045 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0046 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0047 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0048 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0049 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0050 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0051 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0052 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0053 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0054 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0055 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0056 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0057 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0058 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0059 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0060 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0061 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0062 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0063 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0064 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0065 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0066 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0067 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0068 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0069 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0070 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0071 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0072 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0073 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0074 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0075 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0076 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0077 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0078 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0079 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0080 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0081 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0082 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0083 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0084 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0085 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0086 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0087 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0088 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0089 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0090 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0091 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0092 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0093 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0094 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0095 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0096 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0097 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0098 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0099 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0100 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0101 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0102 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0103 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0104 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0105 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0106 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0107 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0108 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0109 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0110 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0111 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0112 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0113 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0114 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0115 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0116 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0117 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0118 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0119 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0120 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0121 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0122 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0123 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0124 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0125 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0126 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0127 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0128 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0129 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0130 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0131 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0132 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0133 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0134 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0135 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0136 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0137 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0138 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0139 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0140 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0141 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0142 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0143 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0144 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0145 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0146 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0147 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0148 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0149 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0150 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0151 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0152 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0153 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0154 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.mat/MAT_0155 (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf.par (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf_abs.rms (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf_abs_mean.rms (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf_final.par (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf_rel.rms (file)
add(ok): sub-02/1stlvl_glm.feat/mc/prefiltered_func_data_mcf_rel_mean.rms (file)
add(ok): sub-02/1stlvl_glm.feat/mc/rot.png (file)
add(ok): sub-02/1stlvl_glm.feat/mc/trans.png (file)
add(ok): sub-02/1stlvl_glm.feat/mean_func.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/rendered_thresh_zstat1.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/rendered_thresh_zstat1.png (file)
add(ok): sub-02/1stlvl_glm.feat/report.html (file)
add(ok): sub-02/1stlvl_glm.feat/report_log.html (file)
add(ok): sub-02/1stlvl_glm.feat/report_poststats.html (file)
add(ok): sub-02/1stlvl_glm.feat/report_prestats.html (file)
add(ok): sub-02/1stlvl_glm.feat/report_reg.html (file)
add(ok): sub-02/1stlvl_glm.feat/report_stats.html (file)
add(ok): sub-02/1stlvl_glm.feat/stats/cope1.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/dof (file)
add(ok): sub-02/1stlvl_glm.feat/stats/logfile (file)
add(ok): sub-02/1stlvl_glm.feat/stats/pe1.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/pe10.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/pe11.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/pe12.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/pe13.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/pe14.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/pe15.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/pe16.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/pe17.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/pe18.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/pe2.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/pe3.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/pe4.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/pe5.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/pe6.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/pe7.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/pe8.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/pe9.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/res4d.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/sigmasquareds.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/smoothness (file)
add(ok): sub-02/1stlvl_glm.feat/stats/threshac1.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/tstat1.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/varcope1.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/stats/zstat1.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/thresh_zstat1.nii.gz (file)
add(ok): sub-02/1stlvl_glm.feat/thresh_zstat1.vol (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev1.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev1.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev10.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev10.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev10p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev11.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev11.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev11p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev12.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev12.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev12p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev1p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev2.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev2.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev2p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev3.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev3.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev3p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev4.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev4.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev4p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev5.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev5.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev5p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev6.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev6.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev6p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev7.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev7.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev7p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev8.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev8.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev8p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev9.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev9.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplot_zstat1_ev9p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev1.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev1.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev10.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev10.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev10p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev11.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev11.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev11p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev12.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev12.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev12p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev1p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev2.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev2.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev2p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev3.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev3.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev3p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev4.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev4.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev4p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev5.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev5.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev5p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev6.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev6.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev6p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev7.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev7.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev7p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev8.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev8.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev8p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev9.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev9.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/ps_tsplotc_zstat1_ev9p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/tsplot_index (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/tsplot_index.html (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/tsplot_zstat1.html (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/tsplot_zstat1.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/tsplot_zstat1.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/tsplot_zstat1p.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/tsplotc_zstat1.png (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/tsplotc_zstat1.txt (file)
add(ok): sub-02/1stlvl_glm.feat/tsplot/tsplotc_zstat1p.png (file)
add(ok): sub-02/1stlvl_glm.feat/.files/fsl.css (file)
add(ok): sub-02/1stlvl_glm.feat/.files/images/3.1r.jpg (file)
add(ok): sub-02/1stlvl_glm.feat/.files/images/3.jpg (file)
add(ok): sub-02/1stlvl_glm.feat/.files/images/flirt-bg.jpg (file)
add(ok): sub-02/1stlvl_glm.feat/.files/images/fsl-bg (file)
add(ok): sub-02/1stlvl_glm.feat/.files/images/fsl-bg.jpg (file)
add(ok): sub-02/1stlvl_glm.feat/.files/images/fsl-logo-big.jpg (file)
add(ok): sub-02/1stlvl_glm.feat/.files/images/fsl-logo.gif (file)
add(ok): sub-02/1stlvl_glm.feat/.files/images/fsl-logo.jpg (file)
add(ok): sub-02/1stlvl_glm.feat/.files/images/fsl-logo.png (file)
add(ok): sub-02/1stlvl_glm.feat/.files/images/fsl-macos-snapshot.tiff (file)
add(ok): sub-02/1stlvl_glm.feat/.files/images/fslstart.jpg (file)
add(ok): sub-02/1stlvl_glm.feat/.files/images/fslstart.png (file)
add(ok): sub-02/1stlvl_glm.feat/.files/images/fugue-bg.jpg (file)
add(ok): sub-02/1stlvl_glm.feat/.files/images/tick.gif (file)
add(ok): sub-02/1stlvl_glm.feat/.files/images/vert2.png (file)
add(ok): sub-02/1stlvl_glm.feat/.ramp.gif (file)
add(ok): .datalad/environments/fsl/image (file)
add(ok): sub-02/1stlvl_design.fsf (file)
add(ok): sub-02/onsets/run-1/body.txt (file)
add(ok): sub-02/onsets/run-1/face.txt (file)
add(ok): sub-02/onsets/run-1/house.txt (file)
add(ok): sub-02/onsets/run-1/object.txt (file)
add(ok): sub-02/onsets/run-1/scene.txt (file)
add(ok): sub-02/onsets/run-1/scramble.txt (file)
save(ok): /home/vagrant/demo/glm_analysis (dataset)
action summary:
  add (ok: 352)
  get (notneeded: 3, ok: 1)
  save (ok: 1)
  unlock (ok: 8)
+ datalad run-procedure cfg_metadatatypes nifti1
[INFO   ] == Command start (output follows) ===== 
[INFO   ] == Command exit (modification check follows) =====                                     
add(notneeded): /home/vagrant/demo/glm_analysis (dataset)
+ datalad aggregate-metadata
[INFO   ] Aggregate metadata for dataset /home/vagrant/demo/glm_analysis 
Metadata extraction: 100%|███████████████████████████| 3.00/3.00 [00:01<00:00, 2.04 extractors/s/home/vagrant/miniconda2/envs/section2/lib/python3.6/site-packages/nibabel/parrec.py:508: UserWarning: PAR/REC version 'None' is currently not supported -- making an attempt to read nevertheless. Please email the NiBabel mailing list, if you are interested in adding support for this version. 
  """.format(version)))
[INFO   ] Update aggregate metadata in dataset at: /home/vagrant/demo/glm_analysis               
aggregate_metadata(ok): /home/vagrant/demo/glm_analysis (dataset)                                
[INFO   ] Attempting to save 6 files/datasets 
save(ok): /home/vagrant/demo/glm_analysis (dataset)                                              
action summary:
  aggregate_metadata (ok: 1)
  save (ok: 1)
```
